### PR TITLE
Break out ModelBuilder on the DbContexts and expose them as extensions.

### DIFF
--- a/src/IdentityServer4.EntityFramework/DbContexts/ClientDbContext.cs
+++ b/src/IdentityServer4.EntityFramework/DbContexts/ClientDbContext.cs
@@ -1,7 +1,7 @@
 ﻿using IdentityServer4.EntityFramework.Entities;
+using IdentityServer4.EntityFramework.Extensions;
 using IdentityServer4.EntityFramework.Interfaces;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace IdentityServer4.EntityFramework.DbContexts
 {
@@ -13,74 +13,7 @@ namespace IdentityServer4.EntityFramework.DbContexts
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Client>(client =>
-            {
-                client.ToTable(EfConstants.TableNames.Client).HasKey(x => x.Id);
-
-                client.Property(x => x.ClientId).HasMaxLength(200).IsRequired();
-                client.Property(x => x.ClientName).HasMaxLength(200).IsRequired();
-                client.Property(x => x.ClientUri).HasMaxLength(2000);
-
-                client.HasMany(x => x.AllowedGrantTypes).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                client.HasMany(x => x.RedirectUris).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                client.HasMany(x => x.PostLogoutRedirectUris).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                client.HasMany(x => x.AllowedScopes).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                client.HasMany(x => x.ClientSecrets).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                client.HasMany(x => x.Claims).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                client.HasMany(x => x.IdentityProviderRestrictions).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                client.HasMany(x => x.AllowedCorsOrigins).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
-            });
-
-            modelBuilder.Entity<ClientGrantType>(grantType =>
-            {
-                grantType.ToTable(EfConstants.TableNames.ClientGrantType);
-                grantType.Property(x => x.GrantType).HasMaxLength(250).IsRequired();
-            });
-
-            modelBuilder.Entity<ClientRedirectUri>(redirectUri =>
-            {
-                redirectUri.ToTable(EfConstants.TableNames.ClientRedirectUri);
-                redirectUri.Property(x => x.RedirectUri).HasMaxLength(2000).IsRequired();
-            });
-
-            modelBuilder.Entity<ClientPostLogoutRedirectUri>(postLogoutRedirectUri =>
-            {
-                postLogoutRedirectUri.ToTable(EfConstants.TableNames.ClientPostLogoutRedirectUri);
-                postLogoutRedirectUri.Property(x => x.PostLogoutRedirectUri).HasMaxLength(2000).IsRequired();
-            });
-
-            modelBuilder.Entity<ClientScope>(scope =>
-            {
-                scope.ToTable(EfConstants.TableNames.ClientScopes);
-                scope.Property(x => x.Scope).HasMaxLength(200).IsRequired();
-            });
-
-            modelBuilder.Entity<ClientSecret>(secret =>
-            {
-                secret.ToTable(EfConstants.TableNames.ClientSecret);
-                secret.Property(x => x.Value).HasMaxLength(250).IsRequired();
-                secret.Property(x => x.Type).HasMaxLength(250);
-                secret.Property(x => x.Description).HasMaxLength(2000);
-            });
-
-            modelBuilder.Entity<ClientClaim>(claim =>
-            {
-                claim.ToTable(EfConstants.TableNames.ClientClaim);
-                claim.Property(x => x.Type).HasMaxLength(250).IsRequired();
-                claim.Property(x => x.Value).HasMaxLength(250).IsRequired();
-            });
-
-            modelBuilder.Entity<ClientIdPRestriction>(idPRestriction =>
-            {
-                idPRestriction.ToTable(EfConstants.TableNames.ClientIdPRestriction);
-                idPRestriction.Property(x => x.Provider).HasMaxLength(200).IsRequired();
-            });
-
-            modelBuilder.Entity<ClientCorsOrigin>(corsOrigin =>
-            {
-                corsOrigin.ToTable(EfConstants.TableNames.ClientCorsOrigin);
-                corsOrigin.Property(x => x.Origin).HasMaxLength(150).IsRequired();
-            });
+            modelBuilder.ConfigureClientContext();
 
             base.OnModelCreating(modelBuilder);
         }

--- a/src/IdentityServer4.EntityFramework/DbContexts/PersistedGrantDbContext.cs
+++ b/src/IdentityServer4.EntityFramework/DbContexts/PersistedGrantDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using IdentityServer4.EntityFramework.Entities;
+using IdentityServer4.EntityFramework.Extensions;
 using IdentityServer4.EntityFramework.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,17 +19,7 @@ namespace IdentityServer4.EntityFramework.DbContexts
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<PersistedGrant>(grant =>
-            {
-                grant.ToTable(EfConstants.TableNames.PersistedGrant);
-                grant.HasKey(x => new {x.Key, x.Type});
-                grant.Property(x => x.SubjectId).IsRequired();
-                grant.Property(x => x.ClientId).HasMaxLength(200).IsRequired();
-                grant.Property(x => x.CreationTime).IsRequired();
-                grant.Property(x => x.Expiration).IsRequired();
-                grant.Property(x => x.Data).IsRequired();
-
-            });
+            modelBuilder.ConfigurePersistedGrantContext();
 
             base.OnModelCreating(modelBuilder);
         }

--- a/src/IdentityServer4.EntityFramework/DbContexts/ScopeDbContext.cs
+++ b/src/IdentityServer4.EntityFramework/DbContexts/ScopeDbContext.cs
@@ -1,7 +1,7 @@
 ﻿using IdentityServer4.EntityFramework.Entities;
+using IdentityServer4.EntityFramework.Extensions;
 using IdentityServer4.EntityFramework.Interfaces;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace IdentityServer4.EntityFramework.DbContexts
 {
@@ -13,31 +13,7 @@ namespace IdentityServer4.EntityFramework.DbContexts
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<ScopeClaim>(scopeClaim =>
-            {
-                scopeClaim.ToTable(EfConstants.TableNames.ScopeClaim).HasKey(x => x.Id);
-                scopeClaim.Property(x => x.Name).HasMaxLength(200).IsRequired();
-                scopeClaim.Property(x => x.Description).HasMaxLength(1000);
-            });
-
-            modelBuilder.Entity<ScopeSecret>(scopeSecret =>
-            {
-                scopeSecret.ToTable(EfConstants.TableNames.ScopeSecrets).HasKey(x => x.Id);
-                scopeSecret.Property(x => x.Description).HasMaxLength(1000);
-                scopeSecret.Property(x => x.Type).HasMaxLength(250);
-                scopeSecret.Property(x => x.Value).HasMaxLength(250);
-            });
-
-            modelBuilder.Entity<Scope>(scope =>
-            {
-                scope.ToTable(EfConstants.TableNames.Scope).HasKey(x => x.Id);
-                scope.Property(x => x.Name).HasMaxLength(200).IsRequired();
-                scope.Property(x => x.DisplayName).HasMaxLength(200);
-                scope.Property(x => x.Description).HasMaxLength(1000);
-                scope.Property(x => x.ClaimsRule).HasMaxLength(200);
-                scope.HasMany(x => x.Claims).WithOne(x => x.Scope).IsRequired().OnDelete(DeleteBehavior.Cascade);
-                scope.HasMany(x => x.ScopeSecrets).WithOne(x => x.Scope).IsRequired().OnDelete(DeleteBehavior.Cascade);
-            });
+            modelBuilder.ConfigureScopeContext();
 
             base.OnModelCreating(modelBuilder);
         }

--- a/src/IdentityServer4.EntityFramework/Extensions/ModelBuilderExtensions.cs
+++ b/src/IdentityServer4.EntityFramework/Extensions/ModelBuilderExtensions.cs
@@ -1,0 +1,126 @@
+﻿using IdentityServer4.EntityFramework.Entities;
+using IdentityServer4.EntityFramework.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace IdentityServer4.EntityFramework.Extensions
+{
+    public static class ModelBuilderExtensions
+    {
+        public static void ConfigureClientContext(this ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Client>(client =>
+            {
+                client.ToTable(EfConstants.TableNames.Client).HasKey(x => x.Id);
+
+                client.Property(x => x.ClientId).HasMaxLength(200).IsRequired();
+                client.Property(x => x.ClientName).HasMaxLength(200).IsRequired();
+                client.Property(x => x.ClientUri).HasMaxLength(2000);
+
+                client.HasMany(x => x.AllowedGrantTypes).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                client.HasMany(x => x.RedirectUris).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                client.HasMany(x => x.PostLogoutRedirectUris).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                client.HasMany(x => x.AllowedScopes).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                client.HasMany(x => x.ClientSecrets).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                client.HasMany(x => x.Claims).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                client.HasMany(x => x.IdentityProviderRestrictions).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                client.HasMany(x => x.AllowedCorsOrigins).WithOne(x => x.Client).IsRequired().OnDelete(DeleteBehavior.Cascade);
+            });
+
+            modelBuilder.Entity<ClientGrantType>(grantType =>
+            {
+                grantType.ToTable(EfConstants.TableNames.ClientGrantType);
+                grantType.Property(x => x.GrantType).HasMaxLength(250).IsRequired();
+            });
+
+            modelBuilder.Entity<ClientRedirectUri>(redirectUri =>
+            {
+                redirectUri.ToTable(EfConstants.TableNames.ClientRedirectUri);
+                redirectUri.Property(x => x.RedirectUri).HasMaxLength(2000).IsRequired();
+            });
+
+            modelBuilder.Entity<ClientPostLogoutRedirectUri>(postLogoutRedirectUri =>
+            {
+                postLogoutRedirectUri.ToTable(EfConstants.TableNames.ClientPostLogoutRedirectUri);
+                postLogoutRedirectUri.Property(x => x.PostLogoutRedirectUri).HasMaxLength(2000).IsRequired();
+            });
+
+            modelBuilder.Entity<ClientScope>(scope =>
+            {
+                scope.ToTable(EfConstants.TableNames.ClientScopes);
+                scope.Property(x => x.Scope).HasMaxLength(200).IsRequired();
+            });
+
+            modelBuilder.Entity<ClientSecret>(secret =>
+            {
+                secret.ToTable(EfConstants.TableNames.ClientSecret);
+                secret.Property(x => x.Value).HasMaxLength(250).IsRequired();
+                secret.Property(x => x.Type).HasMaxLength(250);
+                secret.Property(x => x.Description).HasMaxLength(2000);
+            });
+
+            modelBuilder.Entity<ClientClaim>(claim =>
+            {
+                claim.ToTable(EfConstants.TableNames.ClientClaim);
+                claim.Property(x => x.Type).HasMaxLength(250).IsRequired();
+                claim.Property(x => x.Value).HasMaxLength(250).IsRequired();
+            });
+
+            modelBuilder.Entity<ClientIdPRestriction>(idPRestriction =>
+            {
+                idPRestriction.ToTable(EfConstants.TableNames.ClientIdPRestriction);
+                idPRestriction.Property(x => x.Provider).HasMaxLength(200).IsRequired();
+            });
+
+            modelBuilder.Entity<ClientCorsOrigin>(corsOrigin =>
+            {
+                corsOrigin.ToTable(EfConstants.TableNames.ClientCorsOrigin);
+                corsOrigin.Property(x => x.Origin).HasMaxLength(150).IsRequired();
+            });
+        }
+
+        public static void ConfigurePersistedGrantContext(this ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<PersistedGrant>(grant =>
+            {
+                grant.ToTable(EfConstants.TableNames.PersistedGrant);
+                grant.HasKey(x => new {x.Key, x.Type});
+                grant.Property(x => x.SubjectId).IsRequired();
+                grant.Property(x => x.ClientId).HasMaxLength(200).IsRequired();
+                grant.Property(x => x.CreationTime).IsRequired();
+                grant.Property(x => x.Expiration).IsRequired();
+                grant.Property(x => x.Data).IsRequired();
+
+            });
+        }
+
+        public static void ConfigureScopeContext(this ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ScopeClaim>(scopeClaim =>
+            {
+                scopeClaim.ToTable(EfConstants.TableNames.ScopeClaim).HasKey(x => x.Id);
+                scopeClaim.Property(x => x.Name).HasMaxLength(200).IsRequired();
+                scopeClaim.Property(x => x.Description).HasMaxLength(1000);
+            });
+
+            modelBuilder.Entity<ScopeSecret>(scopeSecret =>
+            {
+                scopeSecret.ToTable(EfConstants.TableNames.ScopeSecrets).HasKey(x => x.Id);
+                scopeSecret.Property(x => x.Description).HasMaxLength(1000);
+                scopeSecret.Property(x => x.Type).HasMaxLength(250);
+                scopeSecret.Property(x => x.Value).HasMaxLength(250);
+            });
+
+            modelBuilder.Entity<Scope>(scope =>
+            {
+                scope.ToTable(EfConstants.TableNames.Scope).HasKey(x => x.Id);
+                scope.Property(x => x.Name).HasMaxLength(200).IsRequired();
+                scope.Property(x => x.DisplayName).HasMaxLength(200);
+                scope.Property(x => x.Description).HasMaxLength(1000);
+                scope.Property(x => x.ClaimsRule).HasMaxLength(200);
+                scope.HasMany(x => x.Claims).WithOne(x => x.Scope).IsRequired().OnDelete(DeleteBehavior.Cascade);
+                scope.HasMany(x => x.ScopeSecrets).WithOne(x => x.Scope).IsRequired().OnDelete(DeleteBehavior.Cascade);
+            });
+        }
+    }
+}


### PR DESCRIPTION
This makes it much easier for integrators to be able to set up migrations on a single context if they desire.

I have implemented this as a single context in my application, but i still require 4 contexts in order to do a Add-Migration and Update-Database from the PackageManager console

If you break it out as such and then just pull in the ModelBuilder, then you will only require a single Context in the main running app in order to use the Migration wizard (sure there's -Context, but that becomes difficult to maintain)