### PR TITLE
Create Scoped DbContext instead of resolving dependency from root ServiceProvider

### DIFF
--- a/src/IdentityServer4.EntityFramework/Services/CorsPolicyService.cs
+++ b/src/IdentityServer4.EntityFramework/Services/CorsPolicyService.cs
@@ -3,38 +3,39 @@
 
 
 using System;
-using System.Threading.Tasks;
-using IdentityServer4.Services;
 using System.Linq;
+using System.Threading.Tasks;
 using IdentityServer4.EntityFramework.Interfaces;
+using IdentityServer4.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace IdentityServer4.EntityFramework.Services
 {
     public class CorsPolicyService : ICorsPolicyService
     {
-        private readonly IConfigurationDbContext _context;
         private readonly ILogger<CorsPolicyService> _logger;
 
-        public CorsPolicyService(IConfigurationDbContext context, ILogger<CorsPolicyService> logger)
+        public CorsPolicyService(IServiceScopeFactory scopeFactory, ILogger<CorsPolicyService> logger)
         {
-            if (context == null) throw new ArgumentNullException(nameof(context));
-
-            _context = context;
+            Context = scopeFactory.CreateScope().ServiceProvider.GetRequiredService<IConfigurationDbContext>();
             _logger = logger;
         }
 
+        private IConfigurationDbContext Context { get; }
+
         public Task<bool> IsOriginAllowedAsync(string origin)
         {
-            var origins = _context.Clients.SelectMany(x => x.AllowedCorsOrigins.Select(y => y.Origin)).ToList();
+                var origins = Context.Clients.SelectMany(x => x.AllowedCorsOrigins.Select(y => y.Origin)).ToList();
 
-            var distinctOrigins = origins.Where(x => x != null).Distinct();
+                var distinctOrigins = origins.Where(x => x != null).Distinct();
 
-            var isAllowed = distinctOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase);
+                var isAllowed = distinctOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase);
 
-            _logger.LogDebug("Origin {origin} is allowed: {originAllowed}", origin, isAllowed);
+                _logger.LogDebug("Origin {origin} is allowed: {originAllowed}", origin, isAllowed);
 
-            return Task.FromResult(isAllowed);
-        }
+                return Task.FromResult(isAllowed);
+            }
+        
     }
 }

--- a/src/IdentityServer4.EntityFramework/Stores/PersistedGrantStore.cs
+++ b/src/IdentityServer4.EntityFramework/Stores/PersistedGrantStore.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,31 +9,33 @@ using IdentityServer4.EntityFramework.Interfaces;
 using IdentityServer4.EntityFramework.Mappers;
 using IdentityServer4.Models;
 using IdentityServer4.Stores;
-using Microsoft.Extensions.Logging;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace IdentityServer4.EntityFramework.Stores
 {
     public class PersistedGrantStore : IPersistedGrantStore
     {
-        private readonly IPersistedGrantDbContext _context;
         private readonly ILogger _logger;
 
-        public PersistedGrantStore(IPersistedGrantDbContext context, ILogger<PersistedGrantStore> logger)
+        public PersistedGrantStore(IServiceScopeFactory scopeFactory, ILogger<PersistedGrantStore> logger)
         {
-            _context = context;
             _logger = logger;
+            Context = scopeFactory.CreateScope().ServiceProvider.GetRequiredService<IPersistedGrantDbContext>();
         }
+
+        private IPersistedGrantDbContext Context { get; }
 
         public Task StoreAsync(PersistedGrant token)
         {
-            var existing = _context.PersistedGrants.SingleOrDefault(x => x.Key == token.Key);
+            var existing = Context.PersistedGrants.SingleOrDefault(x => x.Key == token.Key);
             if (existing == null)
             {
                 _logger.LogDebug("{persistedGrantKey} not found in database", token.Key);
 
                 var persistedGrant = token.ToEntity();
-                _context.PersistedGrants.Add(persistedGrant);
+                Context.PersistedGrants.Add(persistedGrant);
             }
             else
             {
@@ -45,7 +46,7 @@ namespace IdentityServer4.EntityFramework.Stores
 
             try
             {
-                _context.SaveChanges();
+                Context.SaveChanges();
             }
             catch (DbUpdateConcurrencyException ex)
             {
@@ -57,7 +58,7 @@ namespace IdentityServer4.EntityFramework.Stores
 
         public Task<PersistedGrant> GetAsync(string key)
         {
-            var persistedGrant = _context.PersistedGrants.FirstOrDefault(x => x.Key == key);
+            var persistedGrant = Context.PersistedGrants.FirstOrDefault(x => x.Key == key);
             var model = persistedGrant?.ToModel();
 
             _logger.LogDebug("{persistedGrantKey} found in database: {persistedGrantKeyFound}", key, model != null);
@@ -67,7 +68,7 @@ namespace IdentityServer4.EntityFramework.Stores
 
         public Task<IEnumerable<PersistedGrant>> GetAllAsync(string subjectId)
         {
-            var persistedGrants = _context.PersistedGrants.Where(x => x.SubjectId == subjectId).ToList();
+            var persistedGrants = Context.PersistedGrants.Where(x => x.SubjectId == subjectId).ToList();
             var model = persistedGrants.Select(x => x.ToModel());
 
             _logger.LogDebug("{persistedGrantCount} persisted grants found for {subjectId}", persistedGrants.Count, subjectId);
@@ -77,18 +78,18 @@ namespace IdentityServer4.EntityFramework.Stores
 
         public Task RemoveAsync(string key)
         {
-            var persistedGrant = _context.PersistedGrants.FirstOrDefault(x => x.Key == key);
-            if (persistedGrant!= null)
+            var persistedGrant = Context.PersistedGrants.FirstOrDefault(x => x.Key == key);
+            if (persistedGrant != null)
             {
                 _logger.LogDebug("removing {persistedGrantKey} persisted grant from database", key);
 
-                _context.PersistedGrants.Remove(persistedGrant);
+                Context.PersistedGrants.Remove(persistedGrant);
 
                 try
                 {
-                    _context.SaveChanges();
+                    Context.SaveChanges();
                 }
-                catch(DbUpdateConcurrencyException ex)
+                catch (DbUpdateConcurrencyException ex)
                 {
                     _logger.LogInformation("exception removing {persistedGrantKey} persisted grant from database: {error}", key, ex.Message);
                 }
@@ -103,19 +104,21 @@ namespace IdentityServer4.EntityFramework.Stores
 
         public Task RemoveAllAsync(string subjectId, string clientId)
         {
-            var persistedGrants = _context.PersistedGrants.Where(x => x.SubjectId == subjectId && x.ClientId == clientId).ToList();
+            var persistedGrants = Context.PersistedGrants.Where(x => x.SubjectId == subjectId && x.ClientId == clientId).ToList();
 
             _logger.LogDebug("removing {persistedGrantCount} persisted grants from database for subject {subjectId}, clientId {clientId}", persistedGrants.Count, subjectId, clientId);
 
-            _context.PersistedGrants.RemoveRange(persistedGrants);
+            Context.PersistedGrants.RemoveRange(persistedGrants);
 
             try
             {
-                _context.SaveChanges();
+                Context.SaveChanges();
             }
             catch (DbUpdateConcurrencyException ex)
             {
-                _logger.LogInformation("removing {persistedGrantCount} persisted grants from database for subject {subjectId}, clientId {clientId}: {error}", persistedGrants.Count, subjectId, clientId, ex.Message);
+                _logger.LogInformation(
+                    "removing {persistedGrantCount} persisted grants from database for subject {subjectId}, clientId {clientId}: {error}",
+                    persistedGrants.Count, subjectId, clientId, ex.Message);
             }
 
             return Task.FromResult(0);
@@ -123,18 +126,18 @@ namespace IdentityServer4.EntityFramework.Stores
 
         public Task RemoveAllAsync(string subjectId, string clientId, string type)
         {
-            var persistedGrants = _context.PersistedGrants.Where(x =>
+            var persistedGrants = Context.PersistedGrants.Where(x =>
                 x.SubjectId == subjectId &&
                 x.ClientId == clientId &&
                 x.Type == type).ToList();
 
             _logger.LogDebug("removing {persistedGrantCount} persisted grants from database for subject {subjectId}, clientId {clientId}, grantType {persistedGrantType}", persistedGrants.Count, subjectId, clientId, type);
 
-            _context.PersistedGrants.RemoveRange(persistedGrants);
+            Context.PersistedGrants.RemoveRange(persistedGrants);
 
             try
             {
-                _context.SaveChanges();
+                Context.SaveChanges();
             }
             catch (DbUpdateConcurrencyException ex)
             {


### PR DESCRIPTION
Hi,

So in ASP.NET Core 1.1 it is possible to do the following:
```
public IServiceProvider ConfigureServices(IServiceCollection services)
{
    return services.BuildServiceProvider(validateScopes: true);
}
```

Setting this parameter to true will validate the correct lifetime of the dependencies. 
This gave a few errors in the Stores namespace. The DbContexts are registered as Scoped services (which is good) but are being resolved from the root ServiceProvider context which means the dependency will be Singleton. This means that the connection to the DbContext will remain open for the current request.

Now we create a Scoped service within the Transient dependency.
