### PR TITLE
netstandard2.0 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,10 @@ deploy:
     branch: dev
 
 image: Visual Studio 2017
+ 
+install: 
+- cmd: curl -O https://download.microsoft.com/download/0/F/D/0FD852A4-7EA1-4E2A-983A-0484AC19B92C/dotnet-sdk-2.0.0-win-x64.exe 
+- cmd: dotnet-sdk-2.0.0-win-x64.exe /install /quiet /norestart /log install.log  
 
 #---------------------------------#
 #  Skip builds for doc changes    #

--- a/src/IdentityServer4.EntityFramework/IdentityServer4.EntityFramework.csproj
+++ b/src/IdentityServer4.EntityFramework/IdentityServer4.EntityFramework.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>EntityFramework persistence layer for IdentityServer4</Description>
     <Authors>Brock Allen;Dominick Baier;Scott Brady</Authors>
-    <TargetFrameworks>netstandard1.4;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.4;net452</TargetFrameworks>
     <AssemblyName>IdentityServer4.EntityFramework</AssemblyName>
     <PackageId>IdentityServer4.EntityFramework</PackageId>
     <PackageTags>OAuth2;OAuth 2.0;OpenID Connect;Security;Identity;IdentityServer;EntityFramework</PackageTags>
@@ -13,19 +13,31 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="1.3.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.1" />
     <PackageReference Include="AutoMapper" Version="6.0.1" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="IdentityServer4" Version="2.0.0-preview3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
+    <PackageReference Include="IdentityServer4" Version="1.3.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.1" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="IdentityServer4" Version="1.3.1" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/IdentityServer4.EntityFramework/Stores/ResourceStore.cs
+++ b/src/IdentityServer4.EntityFramework/Stores/ResourceStore.cs
@@ -97,22 +97,24 @@ namespace IdentityServer4.EntityFramework.Stores
             return Task.FromResult(results.Select(x => x.ToModel()).ToArray().AsEnumerable());
         }
 
-        public Task<Resources> GetAllResources()
+        public Task<Resources> GetAllResources() => GetAllResourcesAsync();
+
+        public Task<Resources> GetAllResourcesAsync()
         {
             var identity = _context.IdentityResources
-              .Include(x => x.UserClaims);
+                .Include(x => x.UserClaims);
 
             var apis = _context.ApiResources
                 .Include(x => x.Secrets)
                 .Include(x => x.Scopes)
-                    .ThenInclude(s => s.UserClaims)
+                .ThenInclude(s => s.UserClaims)
                 .Include(x => x.UserClaims);
 
             var result = new Resources(
                 identity.ToArray().Select(x => x.ToModel()).AsEnumerable(),
                 apis.ToArray().Select(x => x.ToModel()).AsEnumerable());
 
-            _logger.LogDebug("Found {scopes} as all scopes in database", result.IdentityResources.Select(x=>x.Name).Union(result.ApiResources.SelectMany(x=>x.Scopes).Select(x=>x.Name)));
+            _logger.LogDebug("Found {scopes} as all scopes in database", result.IdentityResources.Select(x => x.Name).Union(result.ApiResources.SelectMany(x => x.Scopes).Select(x => x.Name)));
 
             return Task.FromResult(result);
         }


### PR DESCRIPTION
This is a very minimal change to the csproj file to support netstandard2.0 with the appropriate NuGet dependencies. Only one other change in resourcestore.cs to accommodate a change in IResourceStore from 1.3.1 to 2.0.0-preview3.
This does not affect backwards compatibility with netstandard1.4 or net452, unlike the port by @StefanKert 
