### PR TITLE
allow configurable DbContexts

### DIFF
--- a/src/IdentityServer4.EntityFramework/DbContexts/ConfigurationDbContext.cs
+++ b/src/IdentityServer4.EntityFramework/DbContexts/ConfigurationDbContext.cs
@@ -17,7 +17,27 @@ namespace IdentityServer4.EntityFramework.DbContexts
     /// </summary>
     /// <seealso cref="Microsoft.EntityFrameworkCore.DbContext" />
     /// <seealso cref="IdentityServer4.EntityFramework.Interfaces.IConfigurationDbContext" />
-    public class ConfigurationDbContext : DbContext, IConfigurationDbContext
+    public class ConfigurationDbContext : ConfigurationDbContext<ConfigurationDbContext>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigurationDbContext"/> class.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <param name="storeOptions">The store options.</param>
+        /// <exception cref="ArgumentNullException">storeOptions</exception>
+        public ConfigurationDbContext(DbContextOptions<ConfigurationDbContext> options, ConfigurationStoreOptions storeOptions)
+            : base(options, storeOptions)
+        {
+        }
+    }
+
+    /// <summary>
+    /// DbContext for the IdentityServer configuration data.
+    /// </summary>
+    /// <seealso cref="Microsoft.EntityFrameworkCore.DbContext" />
+    /// <seealso cref="IdentityServer4.EntityFramework.Interfaces.IConfigurationDbContext" />
+    public class ConfigurationDbContext<TContext> : DbContext, IConfigurationDbContext
+        where TContext : DbContext, IConfigurationDbContext
     {
         private readonly ConfigurationStoreOptions storeOptions;
 
@@ -27,7 +47,7 @@ namespace IdentityServer4.EntityFramework.DbContexts
         /// <param name="options">The options.</param>
         /// <param name="storeOptions">The store options.</param>
         /// <exception cref="ArgumentNullException">storeOptions</exception>
-        public ConfigurationDbContext(DbContextOptions<ConfigurationDbContext> options, ConfigurationStoreOptions storeOptions)
+        public ConfigurationDbContext(DbContextOptions<TContext> options, ConfigurationStoreOptions storeOptions)
             : base(options)
         {
             this.storeOptions = storeOptions ?? throw new ArgumentNullException(nameof(storeOptions));

--- a/src/IdentityServer4.EntityFramework/DbContexts/PersistedGrantDbContext.cs
+++ b/src/IdentityServer4.EntityFramework/DbContexts/PersistedGrantDbContext.cs
@@ -17,7 +17,27 @@ namespace IdentityServer4.EntityFramework.DbContexts
     /// </summary>
     /// <seealso cref="Microsoft.EntityFrameworkCore.DbContext" />
     /// <seealso cref="IdentityServer4.EntityFramework.Interfaces.IPersistedGrantDbContext" />
-    public class PersistedGrantDbContext : DbContext, IPersistedGrantDbContext
+    public class PersistedGrantDbContext : PersistedGrantDbContext<PersistedGrantDbContext>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PersistedGrantDbContext"/> class.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <param name="storeOptions">The store options.</param>
+        /// <exception cref="ArgumentNullException">storeOptions</exception>
+        public PersistedGrantDbContext(DbContextOptions<PersistedGrantDbContext> options, OperationalStoreOptions storeOptions)
+            : base(options, storeOptions)
+        {
+        }
+    }
+
+    /// <summary>
+    /// DbContext for the IdentityServer operational data.
+    /// </summary>
+    /// <seealso cref="Microsoft.EntityFrameworkCore.DbContext" />
+    /// <seealso cref="IdentityServer4.EntityFramework.Interfaces.IPersistedGrantDbContext" />
+    public class PersistedGrantDbContext<TContext> : DbContext, IPersistedGrantDbContext
+        where TContext : DbContext, IPersistedGrantDbContext
     {
         private readonly OperationalStoreOptions storeOptions;
 
@@ -27,7 +47,7 @@ namespace IdentityServer4.EntityFramework.DbContexts
         /// <param name="options">The options.</param>
         /// <param name="storeOptions">The store options.</param>
         /// <exception cref="ArgumentNullException">storeOptions</exception>
-        public PersistedGrantDbContext(DbContextOptions<PersistedGrantDbContext> options, OperationalStoreOptions storeOptions)
+        public PersistedGrantDbContext(DbContextOptions options, OperationalStoreOptions storeOptions)
             : base(options)
         {
             if (storeOptions == null) throw new ArgumentNullException(nameof(storeOptions));

--- a/src/IdentityServer4.EntityFramework/Extensions/IdentityServerEntityFrameworkBuilderExtensions.cs
+++ b/src/IdentityServer4.EntityFramework/Extensions/IdentityServerEntityFrameworkBuilderExtensions.cs
@@ -11,9 +11,11 @@ using IdentityServer4.Stores;
 using System;
 using IdentityServer4.EntityFramework.Options;
 using IdentityServer4.EntityFramework;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using System.Threading;
 using System.Threading.Tasks;
+
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -32,22 +34,37 @@ namespace Microsoft.Extensions.DependencyInjection
             this IIdentityServerBuilder builder,
             Action<ConfigurationStoreOptions> storeOptionsAction = null)
         {
+            return builder.AddConfigurationStore<ConfigurationDbContext>(storeOptionsAction);
+        }
+
+        /// <summary>
+        /// Configures EF implementation of IClientStore, IResourceStore, and ICorsPolicyService with IdentityServer.
+        /// </summary>
+        /// <typeparam name="TContext">The IConfigurationDbContext to use.</typeparam>
+        /// <param name="builder">The builder.</param>
+        /// <param name="storeOptionsAction">The store options action.</param>
+        /// <returns></returns>
+        public static IIdentityServerBuilder AddConfigurationStore<TContext>(
+            this IIdentityServerBuilder builder,
+            Action<ConfigurationStoreOptions> storeOptionsAction = null)
+            where TContext : DbContext, IConfigurationDbContext
+        {
             var options = new ConfigurationStoreOptions();
             builder.Services.AddSingleton(options);
             storeOptionsAction?.Invoke(options);
 
             if (options.ResolveDbContextOptions != null)
             {
-                builder.Services.AddDbContext<ConfigurationDbContext>(options.ResolveDbContextOptions);
+                builder.Services.AddDbContext<TContext>(options.ResolveDbContextOptions);
             }
             else
             {
-                builder.Services.AddDbContext<ConfigurationDbContext>(dbCtxBuilder =>
+                builder.Services.AddDbContext<TContext>(dbCtxBuilder =>
                 {
                     options.ConfigureDbContext?.Invoke(dbCtxBuilder);
                 });
             }
-            builder.Services.AddScoped<IConfigurationDbContext, ConfigurationDbContext>();
+            builder.Services.AddScoped<IConfigurationDbContext, TContext>();
 
             builder.Services.AddTransient<IClientStore, ClientStore>();
             builder.Services.AddTransient<IResourceStore, ResourceStore>();
@@ -84,6 +101,21 @@ namespace Microsoft.Extensions.DependencyInjection
             this IIdentityServerBuilder builder,
             Action<OperationalStoreOptions> storeOptionsAction = null)
         {
+            return builder.AddOperationalStore<PersistedGrantDbContext>(storeOptionsAction);
+        }
+
+        /// <summary>
+        /// Configures EF implementation of IPersistedGrantStore with IdentityServer.
+        /// </summary>
+        /// <typeparam name="TContext">The IPersistedGrantDbContext to use.</typeparam>
+        /// <param name="builder">The builder.</param>
+        /// <param name="storeOptionsAction">The store options action.</param>
+        /// <returns></returns>
+        public static IIdentityServerBuilder AddOperationalStore<TContext>(
+            this IIdentityServerBuilder builder,
+            Action<OperationalStoreOptions> storeOptionsAction = null)
+            where TContext : DbContext, IPersistedGrantDbContext
+        {
             builder.Services.AddSingleton<TokenCleanup>();
             builder.Services.AddSingleton<IHostedService, TokenCleanupHost>();
 
@@ -93,17 +125,17 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (storeOptions.ResolveDbContextOptions != null)
             {
-                builder.Services.AddDbContext<PersistedGrantDbContext>(storeOptions.ResolveDbContextOptions);
+                builder.Services.AddDbContext<TContext>(storeOptions.ResolveDbContextOptions);
             }
             else
             {
-                builder.Services.AddDbContext<PersistedGrantDbContext>(dbCtxBuilder =>
+                builder.Services.AddDbContext<TContext>(dbCtxBuilder =>
                 {
                     storeOptions.ConfigureDbContext?.Invoke(dbCtxBuilder);
                 });
             }
 
-            builder.Services.AddScoped<IPersistedGrantDbContext, PersistedGrantDbContext>();
+            builder.Services.AddScoped<IPersistedGrantDbContext, TContext>();
             builder.Services.AddTransient<IPersistedGrantStore, PersistedGrantStore>();
 
             return builder;

--- a/src/IdentityServer4.EntityFramework/Extensions/IdentityServerEntityFrameworkBuilderExtensions.cs
+++ b/src/IdentityServer4.EntityFramework/Extensions/IdentityServerEntityFrameworkBuilderExtensions.cs
@@ -16,7 +16,6 @@ using Microsoft.Extensions.Hosting;
 using System.Threading;
 using System.Threading.Tasks;
 
-
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>


### PR DESCRIPTION
Postgres prefers snake case to camel case.  This pull request allows to specify a custom DbContext that can change table names, fields, keys, and indexes to snake case.  (or any other custom conventions, added fields, etc.).  It is implemented as follows in the example host.  It is non-breaking. 

```
public CustomConfigurationDbContext(DbContextOptions<CustomConfigurationDbContext> options, ConfigurationStoreOptions storeOptions)
   : base(options, storeOptions)
{
}

protected override void OnModelCreating(ModelBuilder builder)
{
    base.OnModelCreating(builder);
    builder.SnakeCaseConvention();
}
```

```
services.AddIdentityServer()
    .AddDeveloperSigningCredential()
    .AddTestUsers(TestUsers.Users)
    // this adds the config data from DB (clients, resources, CORS)
    .AddConfigurationStore<CustomConfigurationDbContext>(options =>
        options.ConfigureDbContext = builder =>
            builder.UseSqlServer(connectionString,
                sql => sql.MigrationsAssembly(migrationsAssembly)))
    ...
```