### PR TITLE
Appveyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ branches:
 build_script:
 - ps: .\build.ps1
 test: off
+services:
+  - mssql2016           # start SQL Server 2016 Developer with SP1
+  - mysql               # start MySQL 5.7 x64 service
+  - postgresql          # start PostgreSQL 9.6 service
 artifacts:
 - path: artifacts/packages/*.nupkg
 deploy:

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/DatabaseProviderBuilder.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/DatabaseProviderBuilder.cs
@@ -29,7 +29,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
         public static DbContextOptions<T> BuildSqlite<T>(string name, object tableOptions) where T : DbContext
         {
             var builder = new DbContextOptionsBuilder<T>();
-            builder.UseSqlite($"Filename=./Test.IdentityServer4.EntityFramework.{name}-2.0.0.db");
+            builder.UseSqlite($"Filename=./Test.IdentityServer4.EntityFramework-2.0.0.{name}.db");
             var options = builder.Options;
 
             using (var context = (T)Activator.CreateInstance(typeof(T), options, tableOptions))
@@ -41,11 +41,53 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
             return options;
         }
 
-        public static DbContextOptions<T> BuildSqlServer<T>(string name, object tableOptions) where T : DbContext
+        public static DbContextOptions<T> BuildLocalDb<T>(string name, object tableOptions) where T : DbContext
         {
             var builder = new DbContextOptionsBuilder<T>();
             builder.UseSqlServer(
                 $@"Data Source=(LocalDb)\MSSQLLocalDB;database=Test.IdentityServer4.EntityFramework-2.0.0.{name};trusted_connection=yes;");
+            var options = builder.Options;
+
+            using (var context = (T)Activator.CreateInstance(typeof(T), options, tableOptions))
+            {
+                context.Database.EnsureCreated();
+            }
+
+            return options;
+        }
+
+        public static DbContextOptions<T> BuildAppVeyorSqlServer2016<T>(string name, object tableOptions) where T : DbContext
+        {
+            var builder = new DbContextOptionsBuilder<T>();
+            builder.UseSqlServer($@"Server=(local)\SQL2016;Database=Test.IdentityServer4.EntityFramework-2.0.0.{name};User ID=sa;Password=Password12!");
+            var options = builder.Options;
+
+            using (var context = (T)Activator.CreateInstance(typeof(T), options, tableOptions))
+            {
+                context.Database.EnsureCreated();
+            }
+
+            return options;
+        }
+
+        public static DbContextOptions<T> BuildAppVeyorMySql<T>(string name, object tableOptions) where T : DbContext
+        {
+            var builder = new DbContextOptionsBuilder<T>();
+            builder.UseMySql($@"server=localhost;database=Test.IdentityServer4.EntityFramework-2.0.0.{name};userid=root;pwd=Password12!;port=3306;persistsecurityinfo=True;");
+            var options = builder.Options;
+
+            using (var context = (T)Activator.CreateInstance(typeof(T), options, tableOptions))
+            {
+                context.Database.EnsureCreated();
+            }
+
+            return options;
+        }
+
+        public static DbContextOptions<T> BuildAppVeyorPostgreSql<T>(string name, object tableOptions) where T : DbContext
+        {
+            var builder = new DbContextOptionsBuilder<T>();
+            builder.UseNpgsql($@"Host=localhost;Database=Test.IdentityServer4.EntityFramework-2.0.0.{name};Username=postgres;Password=Password12!;Port=5432;");
             var options = builder.Options;
 
             using (var context = (T)Activator.CreateInstance(typeof(T), options, tableOptions))

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/DatabaseProviderBuilder.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/DatabaseProviderBuilder.cs
@@ -43,14 +43,14 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
         public static DbContextOptions<T> BuildAppVeyorMySql<T>(string name) where T : DbContext
         {
             var builder = new DbContextOptionsBuilder<T>();
-            builder.UseMySql($@"server=localhost;database=Test.IdentityServer4.EntityFramework-2.0.0.{name};userid=root;pwd=Password12!;port=3306;persistsecurityinfo=True;");
+            builder.UseMySql($@"server=localhost;database=Test.IdentityServer4-2.0.0.{name};userid=root;pwd=Password12!;port=3306;persistsecurityinfo=True;");
             return builder.Options;
         }
 
         public static DbContextOptions<T> BuildAppVeyorPostgreSql<T>(string name) where T : DbContext
         {
             var builder = new DbContextOptionsBuilder<T>();
-            builder.UseNpgsql($@"Host=localhost;Database=Test.IdentityServer4.EntityFramework-2.0.0.{name};Username=postgres;Password=Password12!;Port=5432;");
+            builder.UseNpgsql($@"Host=localhost;Database=Test.IdentityServer4-2.0.0.{name};Username=postgres;Password=Password12!;Port=5432;");
             return builder.Options;
         }
     }

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/DatabaseProviderBuilder.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/DatabaseProviderBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using System;
 using Microsoft.EntityFrameworkCore;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests
@@ -12,90 +11,47 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
     /// </summary>
     public class DatabaseProviderBuilder
     {
-        public static DbContextOptions<T> BuildInMemory<T>(string name, object tableOptions) where T : DbContext
+        public static DbContextOptions<T> BuildInMemory<T>(string name) where T : DbContext
         {
             var builder = new DbContextOptionsBuilder<T>();
             builder.UseInMemoryDatabase(name);
-            var options = builder.Options;
-
-            using (var context = (T)Activator.CreateInstance(typeof(T), options, tableOptions))
-            {
-                context.Database.EnsureCreated();
-            }
-
-            return options;
+            return builder.Options;
         }
 
-        public static DbContextOptions<T> BuildSqlite<T>(string name, object tableOptions) where T : DbContext
+        public static DbContextOptions<T> BuildSqlite<T>(string name) where T : DbContext
         {
             var builder = new DbContextOptionsBuilder<T>();
             builder.UseSqlite($"Filename=./Test.IdentityServer4.EntityFramework-2.0.0.{name}.db");
-            var options = builder.Options;
-
-            using (var context = (T)Activator.CreateInstance(typeof(T), options, tableOptions))
-            {
-                context.Database.OpenConnection();
-                context.Database.EnsureCreated();
-            }
-
-            return options;
+            return builder.Options;
         }
 
-        public static DbContextOptions<T> BuildLocalDb<T>(string name, object tableOptions) where T : DbContext
+        public static DbContextOptions<T> BuildLocalDb<T>(string name) where T : DbContext
         {
             var builder = new DbContextOptionsBuilder<T>();
             builder.UseSqlServer(
                 $@"Data Source=(LocalDb)\MSSQLLocalDB;database=Test.IdentityServer4.EntityFramework-2.0.0.{name};trusted_connection=yes;");
-            var options = builder.Options;
-
-            using (var context = (T)Activator.CreateInstance(typeof(T), options, tableOptions))
-            {
-                context.Database.EnsureCreated();
-            }
-
-            return options;
+            return builder.Options;
         }
 
-        public static DbContextOptions<T> BuildAppVeyorSqlServer2016<T>(string name, object tableOptions) where T : DbContext
+        public static DbContextOptions<T> BuildAppVeyorSqlServer2016<T>(string name) where T : DbContext
         {
             var builder = new DbContextOptionsBuilder<T>();
             builder.UseSqlServer($@"Server=(local)\SQL2016;Database=Test.IdentityServer4.EntityFramework-2.0.0.{name};User ID=sa;Password=Password12!");
-            var options = builder.Options;
-
-            using (var context = (T)Activator.CreateInstance(typeof(T), options, tableOptions))
-            {
-                context.Database.EnsureCreated();
-            }
-
-            return options;
+            return builder.Options;
         }
 
-        public static DbContextOptions<T> BuildAppVeyorMySql<T>(string name, object tableOptions) where T : DbContext
+        public static DbContextOptions<T> BuildAppVeyorMySql<T>(string name) where T : DbContext
         {
             var builder = new DbContextOptionsBuilder<T>();
             builder.UseMySql($@"server=localhost;database=Test.IdentityServer4.EntityFramework-2.0.0.{name};userid=root;pwd=Password12!;port=3306;persistsecurityinfo=True;");
-            var options = builder.Options;
-
-            using (var context = (T)Activator.CreateInstance(typeof(T), options, tableOptions))
-            {
-                context.Database.EnsureCreated();
-            }
-
-            return options;
+            return builder.Options;
         }
 
-        public static DbContextOptions<T> BuildAppVeyorPostgreSql<T>(string name, object tableOptions) where T : DbContext
+        public static DbContextOptions<T> BuildAppVeyorPostgreSql<T>(string name) where T : DbContext
         {
             var builder = new DbContextOptionsBuilder<T>();
             builder.UseNpgsql($@"Host=localhost;Database=Test.IdentityServer4.EntityFramework-2.0.0.{name};Username=postgres;Password=Password12!;Port=5432;");
-            var options = builder.Options;
-
-            using (var context = (T)Activator.CreateInstance(typeof(T), options, tableOptions))
-            {
-                context.Database.EnsureCreated();
-            }
-
-            return options;
+            return builder.Options;
         }
     }
 }

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/DbContexts/ClientDbContextTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/DbContexts/ClientDbContextTests.cs
@@ -11,20 +11,15 @@ using Xunit;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
 {
-    public class ClientDbContextTests : IClassFixture<DatabaseProviderFixture<ConfigurationDbContext>>
+    public class ClientDbContextTests : IntegrationTest<ClientDbContextTests, ConfigurationDbContext, ConfigurationStoreOptions>
     {
-        private static readonly ConfigurationStoreOptions StoreOptions = new ConfigurationStoreOptions();
-        public static readonly TheoryData<DbContextOptions<ConfigurationDbContext>> TestDatabaseProviders = new TheoryData<DbContextOptions<ConfigurationDbContext>>
+        public ClientDbContextTests(DatabaseProviderFixture<ConfigurationDbContext> fixture) : base(fixture)
         {
-            DatabaseProviderBuilder.BuildInMemory<ConfigurationDbContext>(nameof(ClientDbContextTests), StoreOptions),
-            DatabaseProviderBuilder.BuildSqlite<ConfigurationDbContext>(nameof(ClientDbContextTests), StoreOptions),
-            DatabaseProviderBuilder.BuildLocalDb<ConfigurationDbContext>(nameof(ClientDbContextTests), StoreOptions)
-        };
-
-        public ClientDbContextTests(DatabaseProviderFixture<ConfigurationDbContext> fixture)
-        {
-            fixture.Options = TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>)y)).ToList();
-            fixture.StoreOptions = StoreOptions;
+            foreach (var options in TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>)y)).ToList())
+            {
+                using (var context = new ConfigurationDbContext(options, StoreOptions))
+                    context.Database.EnsureCreated();
+            }
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/DbContexts/ClientDbContextTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/DbContexts/ClientDbContextTests.cs
@@ -18,7 +18,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
         {
             DatabaseProviderBuilder.BuildInMemory<ConfigurationDbContext>(nameof(ClientDbContextTests), StoreOptions),
             DatabaseProviderBuilder.BuildSqlite<ConfigurationDbContext>(nameof(ClientDbContextTests), StoreOptions),
-            DatabaseProviderBuilder.BuildSqlServer<ConfigurationDbContext>(nameof(ClientDbContextTests), StoreOptions)
+            DatabaseProviderBuilder.BuildLocalDb<ConfigurationDbContext>(nameof(ClientDbContextTests), StoreOptions)
         };
 
         public ClientDbContextTests(DatabaseProviderFixture<ConfigurationDbContext> fixture)

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/IdentityServer4.EntityFramework.IntegrationTests.csproj
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/IdentityServer4.EntityFramework.IntegrationTests.csproj
@@ -11,6 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.1" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.0.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/IdentityServer4.EntityFramework.IntegrationTests.csproj
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/IdentityServer4.EntityFramework.IntegrationTests.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.1" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.0.1" />

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/IntegrationTest.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/IntegrationTest.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace IdentityServer4.EntityFramework.IntegrationTests
+{
+    /// <summary>
+    /// Base class for integration tests, responsible for initializing test database providers & an xUnit class fixture
+    /// </summary>
+    /// <typeparam name="TClass">The type of the class.</typeparam>
+    /// <typeparam name="TDbContext">The type of the database context.</typeparam>
+    /// <typeparam name="TStoreOption">The type of the store option.</typeparam>
+    /// <seealso cref="Xunit.IClassFixture{IdentityServer4.EntityFramework.IntegrationTests.DatabaseProviderFixture{TDbContext}}" />
+    public class IntegrationTest<TClass, TDbContext, TStoreOption> : IClassFixture<DatabaseProviderFixture<TDbContext>>
+        where TDbContext : DbContext
+    {
+        public static readonly TheoryData<DbContextOptions<TDbContext>> TestDatabaseProviders;
+        protected readonly TStoreOption StoreOptions = Activator.CreateInstance<TStoreOption>();
+
+        static IntegrationTest()
+        {
+            TestDatabaseProviders = new TheoryData<DbContextOptions<TDbContext>>
+            {
+                DatabaseProviderBuilder.BuildInMemory<TDbContext>(typeof(TClass).Name),
+                DatabaseProviderBuilder.BuildSqlite<TDbContext>(typeof(TClass).Name),
+                DatabaseProviderBuilder.BuildLocalDb<TDbContext>(typeof(TClass).Name)
+            };
+        }
+
+        protected IntegrationTest(DatabaseProviderFixture<TDbContext> fixture)
+        {
+            fixture.Options = TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<TDbContext>)y)).ToList();
+            fixture.StoreOptions = StoreOptions;
+        }
+    }
+}

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Services/CorsPolicyServiceTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Services/CorsPolicyServiceTests.cs
@@ -25,7 +25,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Services
         {
             DatabaseProviderBuilder.BuildInMemory<ConfigurationDbContext>(nameof(CorsPolicyServiceTests), StoreOptions),
             DatabaseProviderBuilder.BuildSqlite<ConfigurationDbContext>(nameof(CorsPolicyServiceTests), StoreOptions),
-            DatabaseProviderBuilder.BuildSqlServer<ConfigurationDbContext>(nameof(CorsPolicyServiceTests), StoreOptions)
+            DatabaseProviderBuilder.BuildLocalDb<ConfigurationDbContext>(nameof(CorsPolicyServiceTests), StoreOptions)
         };
 
         public CorsPolicyServiceTests(DatabaseProviderFixture<ConfigurationDbContext> fixture)

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Services/CorsPolicyServiceTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Services/CorsPolicyServiceTests.cs
@@ -18,20 +18,15 @@ using IdentityServer4.EntityFramework.Interfaces;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests.Services
 {
-    public class CorsPolicyServiceTests : IClassFixture<DatabaseProviderFixture<ConfigurationDbContext>>
+    public class CorsPolicyServiceTests : IntegrationTest<CorsPolicyServiceTests, ConfigurationDbContext, ConfigurationStoreOptions>
     {
-        private static readonly ConfigurationStoreOptions StoreOptions = new ConfigurationStoreOptions();
-        public static readonly TheoryData<DbContextOptions<ConfigurationDbContext>> TestDatabaseProviders = new TheoryData<DbContextOptions<ConfigurationDbContext>>
+        public CorsPolicyServiceTests(DatabaseProviderFixture<ConfigurationDbContext> fixture) : base(fixture)
         {
-            DatabaseProviderBuilder.BuildInMemory<ConfigurationDbContext>(nameof(CorsPolicyServiceTests), StoreOptions),
-            DatabaseProviderBuilder.BuildSqlite<ConfigurationDbContext>(nameof(CorsPolicyServiceTests), StoreOptions),
-            DatabaseProviderBuilder.BuildLocalDb<ConfigurationDbContext>(nameof(CorsPolicyServiceTests), StoreOptions)
-        };
-
-        public CorsPolicyServiceTests(DatabaseProviderFixture<ConfigurationDbContext> fixture)
-        {
-            fixture.Options = TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>)y)).ToList();
-            fixture.StoreOptions = StoreOptions;
+            foreach (var options in TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>)y)).ToList())
+            {
+                using (var context = new ConfigurationDbContext(options, StoreOptions))
+                    context.Database.EnsureCreated();
+            }
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ClientStoreTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ClientStoreTests.cs
@@ -14,20 +14,15 @@ using Xunit;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
 {
-    public class ClientStoreTests : IClassFixture<DatabaseProviderFixture<ConfigurationDbContext>>
+    public class ClientStoreTests : IntegrationTest<ClientStoreTests, ConfigurationDbContext, ConfigurationStoreOptions>
     {
-        private static readonly ConfigurationStoreOptions StoreOptions = new ConfigurationStoreOptions();
-        public static readonly TheoryData<DbContextOptions<ConfigurationDbContext>> TestDatabaseProviders = new TheoryData<DbContextOptions<ConfigurationDbContext>>
+        public ClientStoreTests(DatabaseProviderFixture<ConfigurationDbContext> fixture) : base(fixture)
         {
-            DatabaseProviderBuilder.BuildInMemory<ConfigurationDbContext>(nameof(ClientStoreTests), StoreOptions),
-            DatabaseProviderBuilder.BuildSqlite<ConfigurationDbContext>(nameof(ClientStoreTests), StoreOptions),
-            DatabaseProviderBuilder.BuildLocalDb<ConfigurationDbContext>(nameof(ClientStoreTests), StoreOptions)
-        };
-
-        public ClientStoreTests(DatabaseProviderFixture<ConfigurationDbContext> fixture)
-        {
-            fixture.Options = TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>)y)).ToList();
-            fixture.StoreOptions = StoreOptions;
+            foreach (var options in TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>) y)).ToList())
+            {
+                using (var context = new ConfigurationDbContext(options, StoreOptions))
+                    context.Database.EnsureCreated();
+            }
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ClientStoreTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ClientStoreTests.cs
@@ -21,7 +21,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         {
             DatabaseProviderBuilder.BuildInMemory<ConfigurationDbContext>(nameof(ClientStoreTests), StoreOptions),
             DatabaseProviderBuilder.BuildSqlite<ConfigurationDbContext>(nameof(ClientStoreTests), StoreOptions),
-            DatabaseProviderBuilder.BuildSqlServer<ConfigurationDbContext>(nameof(ClientStoreTests), StoreOptions)
+            DatabaseProviderBuilder.BuildLocalDb<ConfigurationDbContext>(nameof(ClientStoreTests), StoreOptions)
         };
 
         public ClientStoreTests(DatabaseProviderFixture<ConfigurationDbContext> fixture)

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/PersistedGrantStoreTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/PersistedGrantStoreTests.cs
@@ -15,20 +15,15 @@ using Xunit;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
 {
-    public class PersistedGrantStoreTests : IClassFixture<DatabaseProviderFixture<PersistedGrantDbContext>>
+    public class PersistedGrantStoreTests : IntegrationTest<PersistedGrantStoreTests, PersistedGrantDbContext, OperationalStoreOptions>
     {
-        private static readonly OperationalStoreOptions StoreOptions = new OperationalStoreOptions();
-        public static readonly TheoryData<DbContextOptions<PersistedGrantDbContext>> TestDatabaseProviders = new TheoryData<DbContextOptions<PersistedGrantDbContext>>
+        public PersistedGrantStoreTests(DatabaseProviderFixture<PersistedGrantDbContext> fixture) : base(fixture)
         {
-            DatabaseProviderBuilder.BuildInMemory<PersistedGrantDbContext>(nameof(PersistedGrantStoreTests), StoreOptions),
-            DatabaseProviderBuilder.BuildSqlite<PersistedGrantDbContext>(nameof(PersistedGrantStoreTests), StoreOptions),
-            DatabaseProviderBuilder.BuildLocalDb<PersistedGrantDbContext>(nameof(PersistedGrantStoreTests), StoreOptions)
-        };
-
-        public PersistedGrantStoreTests(DatabaseProviderFixture<PersistedGrantDbContext> fixture)
-        {
-            fixture.Options = TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<PersistedGrantDbContext>)y)).ToList();
-            fixture.StoreOptions = StoreOptions;
+            foreach (var options in TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<PersistedGrantDbContext>)y)).ToList())
+            {
+                using (var context = new PersistedGrantDbContext(options, StoreOptions))
+                    context.Database.EnsureCreated();
+            }
         }
 
         private static PersistedGrant CreateTestObject()

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/PersistedGrantStoreTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/PersistedGrantStoreTests.cs
@@ -22,7 +22,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         {
             DatabaseProviderBuilder.BuildInMemory<PersistedGrantDbContext>(nameof(PersistedGrantStoreTests), StoreOptions),
             DatabaseProviderBuilder.BuildSqlite<PersistedGrantDbContext>(nameof(PersistedGrantStoreTests), StoreOptions),
-            DatabaseProviderBuilder.BuildSqlServer<PersistedGrantDbContext>(nameof(PersistedGrantStoreTests), StoreOptions)
+            DatabaseProviderBuilder.BuildLocalDb<PersistedGrantDbContext>(nameof(PersistedGrantStoreTests), StoreOptions)
         };
 
         public PersistedGrantStoreTests(DatabaseProviderFixture<PersistedGrantDbContext> fixture)

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ResourceStoreTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ResourceStoreTests.cs
@@ -24,7 +24,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         {
             DatabaseProviderBuilder.BuildInMemory<ConfigurationDbContext>(nameof(ScopeStoreTests), StoreOptions),
             DatabaseProviderBuilder.BuildSqlite<ConfigurationDbContext>(nameof(ScopeStoreTests), StoreOptions),
-            DatabaseProviderBuilder.BuildSqlServer<ConfigurationDbContext>(nameof(ScopeStoreTests), StoreOptions)
+            DatabaseProviderBuilder.BuildLocalDb<ConfigurationDbContext>(nameof(ScopeStoreTests), StoreOptions)
         };
 
         public ScopeStoreTests(DatabaseProviderFixture<ConfigurationDbContext> fixture)

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ResourceStoreTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ResourceStoreTests.cs
@@ -17,20 +17,15 @@ using Xunit;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
 {
-    public class ScopeStoreTests : IClassFixture<DatabaseProviderFixture<ConfigurationDbContext>>
+    public class ScopeStoreTests : IntegrationTest<ScopeStoreTests, ConfigurationDbContext, ConfigurationStoreOptions>
     {
-        private static readonly ConfigurationStoreOptions StoreOptions = new ConfigurationStoreOptions();
-        public static readonly TheoryData<DbContextOptions<ConfigurationDbContext>> TestDatabaseProviders = new TheoryData<DbContextOptions<ConfigurationDbContext>>
+        public ScopeStoreTests(DatabaseProviderFixture<ConfigurationDbContext> fixture) : base(fixture)
         {
-            DatabaseProviderBuilder.BuildInMemory<ConfigurationDbContext>(nameof(ScopeStoreTests), StoreOptions),
-            DatabaseProviderBuilder.BuildSqlite<ConfigurationDbContext>(nameof(ScopeStoreTests), StoreOptions),
-            DatabaseProviderBuilder.BuildLocalDb<ConfigurationDbContext>(nameof(ScopeStoreTests), StoreOptions)
-        };
-
-        public ScopeStoreTests(DatabaseProviderFixture<ConfigurationDbContext> fixture)
-        {
-            fixture.Options = TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>)y)).ToList();
-            fixture.StoreOptions = StoreOptions;
+            foreach (var options in TestDatabaseProviders.SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>)y)).ToList())
+            {
+                using (var context = new ConfigurationDbContext(options, StoreOptions))
+                    context.Database.EnsureCreated();
+            }
         }
 
         private static IdentityResource CreateIdentityTestResource()


### PR DESCRIPTION
When running in AppVeyor, integration tests now run against SQL Server 2016, MySql, and PostgreSQL.

This will need some AppVeyor settings to be modified by @leastprivilege to add the database provider to the list of services (see image):
<img width="645" alt="screenshot-2018-1-26 identity-express-manager-api - appveyor" src="https://user-images.githubusercontent.com/5598125/35432245-59fc18a6-0277-11e8-9be8-45dc9040c24b.png">

Addresses: https://github.com/IdentityServer/IdentityServer4/issues/1865

Change notes:
 - Moved database provider & class fixture initialization into base class
 - Added check for AppVeyor environment variable to decide which database providers to test