### PR TITLE
Switch to Async methods for Entity Framework calls

### DIFF
--- a/src/IdentityServer4.EntityFramework/Services/CorsPolicyService.cs
+++ b/src/IdentityServer4.EntityFramework/Services/CorsPolicyService.cs
@@ -10,6 +10,7 @@ using IdentityServer4.EntityFramework.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
 
 namespace IdentityServer4.EntityFramework.Services
 {
@@ -39,20 +40,22 @@ namespace IdentityServer4.EntityFramework.Services
         /// </summary>
         /// <param name="origin">The origin.</param>
         /// <returns></returns>
-        public Task<bool> IsOriginAllowedAsync(string origin)
+        public async Task<bool> IsOriginAllowedAsync(string origin)
         {
             // doing this here and not in the ctor because: https://github.com/aspnet/CORS/issues/105
             var dbContext = _context.HttpContext.RequestServices.GetRequiredService<IConfigurationDbContext>();
 
-            var origins = dbContext.Clients.SelectMany(x => x.AllowedCorsOrigins.Select(y => y.Origin)).ToList();
-
-            var distinctOrigins = origins.Where(x => x != null).Distinct();
+            var distinctOrigins = await dbContext.Clients
+                .SelectMany(x => x.AllowedCorsOrigins.Select(y => y.Origin))
+                .Where(x => x != null)
+                .Distinct()
+                .ToListAsync();
 
             var isAllowed = distinctOrigins.Contains(origin, StringComparer.OrdinalIgnoreCase);
 
             _logger.LogDebug("Origin {origin} is allowed: {originAllowed}", origin, isAllowed);
 
-            return Task.FromResult(isAllowed);
+            return isAllowed;
         }
     }
 }

--- a/src/IdentityServer4.EntityFramework/Stores/ClientStore.cs
+++ b/src/IdentityServer4.EntityFramework/Stores/ClientStore.cs
@@ -42,9 +42,9 @@ namespace IdentityServer4.EntityFramework.Stores
         /// <returns>
         /// The client
         /// </returns>
-        public Task<Client> FindClientByIdAsync(string clientId)
+        public async Task<Client> FindClientByIdAsync(string clientId)
         {
-            var client = _context.Clients
+            var client = await _context.Clients
                 .Include(x => x.AllowedGrantTypes)
                 .Include(x => x.RedirectUris)
                 .Include(x => x.PostLogoutRedirectUris)
@@ -54,12 +54,12 @@ namespace IdentityServer4.EntityFramework.Stores
                 .Include(x => x.IdentityProviderRestrictions)
                 .Include(x => x.AllowedCorsOrigins)
                 .Include(x => x.Properties)
-                .FirstOrDefault(x => x.ClientId == clientId);
+                .FirstOrDefaultAsync(x => x.ClientId == clientId);
             var model = client?.ToModel();
 
             _logger.LogDebug("{clientId} found in database: {clientIdFound}", clientId, model != null);
 
-            return Task.FromResult(model);
+            return model;
         }
     }
 }

--- a/src/IdentityServer4.EntityFramework/Stores/PersistedGrantStore.cs
+++ b/src/IdentityServer4.EntityFramework/Stores/PersistedGrantStore.cs
@@ -39,9 +39,9 @@ namespace IdentityServer4.EntityFramework.Stores
         /// </summary>
         /// <param name="token">The token.</param>
         /// <returns></returns>
-        public Task StoreAsync(PersistedGrant token)
+        public async Task StoreAsync(PersistedGrant token)
         {
-            var existing = _context.PersistedGrants.SingleOrDefault(x => x.Key == token.Key);
+            var existing = await _context.PersistedGrants.SingleOrDefaultAsync(x => x.Key == token.Key);
             if (existing == null)
             {
                 _logger.LogDebug("{persistedGrantKey} not found in database", token.Key);
@@ -58,14 +58,12 @@ namespace IdentityServer4.EntityFramework.Stores
 
             try
             {
-                _context.SaveChanges();
+                await _context.SaveChangesAsync();
             }
             catch (DbUpdateConcurrencyException ex)
             {
                 _logger.LogWarning("exception updating {persistedGrantKey} persisted grant in database: {error}", token.Key, ex.Message);
             }
-
-            return Task.FromResult(0);
         }
 
         /// <summary>
@@ -73,14 +71,14 @@ namespace IdentityServer4.EntityFramework.Stores
         /// </summary>
         /// <param name="key">The key.</param>
         /// <returns></returns>
-        public Task<PersistedGrant> GetAsync(string key)
+        public async Task<PersistedGrant> GetAsync(string key)
         {
-            var persistedGrant = _context.PersistedGrants.FirstOrDefault(x => x.Key == key);
+            var persistedGrant = await _context.PersistedGrants.FirstOrDefaultAsync(x => x.Key == key);
             var model = persistedGrant?.ToModel();
 
             _logger.LogDebug("{persistedGrantKey} found in database: {persistedGrantKeyFound}", key, model != null);
 
-            return Task.FromResult(model);
+            return model;
         }
 
         /// <summary>
@@ -88,14 +86,14 @@ namespace IdentityServer4.EntityFramework.Stores
         /// </summary>
         /// <param name="subjectId">The subject identifier.</param>
         /// <returns></returns>
-        public Task<IEnumerable<PersistedGrant>> GetAllAsync(string subjectId)
+        public async Task<IEnumerable<PersistedGrant>> GetAllAsync(string subjectId)
         {
-            var persistedGrants = _context.PersistedGrants.Where(x => x.SubjectId == subjectId).ToList();
+            var persistedGrants = await _context.PersistedGrants.Where(x => x.SubjectId == subjectId).ToListAsync();
             var model = persistedGrants.Select(x => x.ToModel());
 
             _logger.LogDebug("{persistedGrantCount} persisted grants found for {subjectId}", persistedGrants.Count, subjectId);
 
-            return Task.FromResult(model);
+            return model;
         }
 
         /// <summary>
@@ -103,9 +101,9 @@ namespace IdentityServer4.EntityFramework.Stores
         /// </summary>
         /// <param name="key">The key.</param>
         /// <returns></returns>
-        public Task RemoveAsync(string key)
+        public async Task RemoveAsync(string key)
         {
-            var persistedGrant = _context.PersistedGrants.FirstOrDefault(x => x.Key == key);
+            var persistedGrant = await _context.PersistedGrants.FirstOrDefaultAsync(x => x.Key == key);
             if (persistedGrant!= null)
             {
                 _logger.LogDebug("removing {persistedGrantKey} persisted grant from database", key);
@@ -114,7 +112,7 @@ namespace IdentityServer4.EntityFramework.Stores
 
                 try
                 {
-                    _context.SaveChanges();
+                    await _context.SaveChangesAsync();
                 }
                 catch(DbUpdateConcurrencyException ex)
                 {
@@ -125,8 +123,6 @@ namespace IdentityServer4.EntityFramework.Stores
             {
                 _logger.LogDebug("no {persistedGrantKey} persisted grant found in database", key);
             }
-
-            return Task.FromResult(0);
         }
 
         /// <summary>
@@ -135,9 +131,9 @@ namespace IdentityServer4.EntityFramework.Stores
         /// <param name="subjectId">The subject identifier.</param>
         /// <param name="clientId">The client identifier.</param>
         /// <returns></returns>
-        public Task RemoveAllAsync(string subjectId, string clientId)
+        public async Task RemoveAllAsync(string subjectId, string clientId)
         {
-            var persistedGrants = _context.PersistedGrants.Where(x => x.SubjectId == subjectId && x.ClientId == clientId).ToList();
+            var persistedGrants = await _context.PersistedGrants.Where(x => x.SubjectId == subjectId && x.ClientId == clientId).ToListAsync();
 
             _logger.LogDebug("removing {persistedGrantCount} persisted grants from database for subject {subjectId}, clientId {clientId}", persistedGrants.Count, subjectId, clientId);
 
@@ -145,14 +141,12 @@ namespace IdentityServer4.EntityFramework.Stores
 
             try
             {
-                _context.SaveChanges();
+                await _context.SaveChangesAsync();
             }
             catch (DbUpdateConcurrencyException ex)
             {
                 _logger.LogInformation("removing {persistedGrantCount} persisted grants from database for subject {subjectId}, clientId {clientId}: {error}", persistedGrants.Count, subjectId, clientId, ex.Message);
             }
-
-            return Task.FromResult(0);
         }
 
         /// <summary>
@@ -162,12 +156,12 @@ namespace IdentityServer4.EntityFramework.Stores
         /// <param name="clientId">The client identifier.</param>
         /// <param name="type">The type.</param>
         /// <returns></returns>
-        public Task RemoveAllAsync(string subjectId, string clientId, string type)
+        public async Task RemoveAllAsync(string subjectId, string clientId, string type)
         {
-            var persistedGrants = _context.PersistedGrants.Where(x =>
+            var persistedGrants = await _context.PersistedGrants.Where(x =>
                 x.SubjectId == subjectId &&
                 x.ClientId == clientId &&
-                x.Type == type).ToList();
+                x.Type == type).ToListAsync();
 
             _logger.LogDebug("removing {persistedGrantCount} persisted grants from database for subject {subjectId}, clientId {clientId}, grantType {persistedGrantType}", persistedGrants.Count, subjectId, clientId, type);
 
@@ -175,14 +169,12 @@ namespace IdentityServer4.EntityFramework.Stores
 
             try
             {
-                _context.SaveChanges();
+                await _context.SaveChangesAsync();
             }
             catch (DbUpdateConcurrencyException ex)
             {
                 _logger.LogInformation("exception removing {persistedGrantCount} persisted grants from database for subject {subjectId}, clientId {clientId}, grantType {persistedGrantType}: {error}", persistedGrants.Count, subjectId, clientId, type, ex.Message);
             }
-
-            return Task.FromResult(0);
         }
     }
 }

--- a/src/IdentityServer4.EntityFramework/Stores/ResourceStore.cs
+++ b/src/IdentityServer4.EntityFramework/Stores/ResourceStore.cs
@@ -41,7 +41,7 @@ namespace IdentityServer4.EntityFramework.Stores
         /// </summary>
         /// <param name="name">The name.</param>
         /// <returns></returns>
-        public Task<ApiResource> FindApiResourceAsync(string name)
+        public async Task<ApiResource> FindApiResourceAsync(string name)
         {
             var query =
                 from apiResource in _context.ApiResources
@@ -54,7 +54,7 @@ namespace IdentityServer4.EntityFramework.Stores
                     .ThenInclude(s => s.UserClaims)
                 .Include(x => x.UserClaims);
 
-            var api = apis.FirstOrDefault();
+            var api = await apis.FirstOrDefaultAsync();
 
             if (api != null)
             {
@@ -65,7 +65,7 @@ namespace IdentityServer4.EntityFramework.Stores
                 _logger.LogDebug("Did not find {api} API resource in database", name);
             }
 
-            return Task.FromResult(api.ToModel());
+            return api.ToModel();
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace IdentityServer4.EntityFramework.Stores
         /// </summary>
         /// <param name="scopeNames"></param>
         /// <returns></returns>
-        public Task<IEnumerable<ApiResource>> FindApiResourcesByScopeAsync(IEnumerable<string> scopeNames)
+        public async Task<IEnumerable<ApiResource>> FindApiResourcesByScopeAsync(IEnumerable<string> scopeNames)
         {
             var names = scopeNames.ToArray();
 
@@ -88,12 +88,12 @@ namespace IdentityServer4.EntityFramework.Stores
                     .ThenInclude(s => s.UserClaims)
                 .Include(x => x.UserClaims);
 
-            var results = apis.ToArray();
+            var results = await apis.ToArrayAsync();
             var models = results.Select(x => x.ToModel()).ToArray();
 
             _logger.LogDebug("Found {scopes} API scopes in database", models.SelectMany(x => x.Scopes).Select(x => x.Name));
 
-            return Task.FromResult(models.AsEnumerable());
+            return models.AsEnumerable();
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace IdentityServer4.EntityFramework.Stores
         /// </summary>
         /// <param name="scopeNames"></param>
         /// <returns></returns>
-        public Task<IEnumerable<IdentityResource>> FindIdentityResourcesByScopeAsync(IEnumerable<string> scopeNames)
+        public async Task<IEnumerable<IdentityResource>> FindIdentityResourcesByScopeAsync(IEnumerable<string> scopeNames)
         {
             var scopes = scopeNames.ToArray();
 
@@ -113,35 +113,37 @@ namespace IdentityServer4.EntityFramework.Stores
             var resources = query
                 .Include(x => x.UserClaims);
 
-            var results = resources.ToArray();
+            var results = await resources.ToArrayAsync();
 
             _logger.LogDebug("Found {scopes} identity scopes in database", results.Select(x => x.Name));
 
-            return Task.FromResult(results.Select(x => x.ToModel()).ToArray().AsEnumerable());
+            return results.Select(x => x.ToModel()).ToArray().AsEnumerable();
         }
 
         /// <summary>
         /// Gets all resources.
         /// </summary>
         /// <returns></returns>
-        public Task<Resources> GetAllResourcesAsync()
+        public async Task<Resources> GetAllResourcesAsync()
         {
-            var identity = _context.IdentityResources
-              .Include(x => x.UserClaims);
+            var identity = await _context.IdentityResources
+              .Include(x => x.UserClaims)
+              .ToArrayAsync();
 
-            var apis = _context.ApiResources
+            var apis = await _context.ApiResources
                 .Include(x => x.Secrets)
                 .Include(x => x.Scopes)
                     .ThenInclude(s => s.UserClaims)
-                .Include(x => x.UserClaims);
+                .Include(x => x.UserClaims)
+                .ToArrayAsync();
 
             var result = new Resources(
-                identity.ToArray().Select(x => x.ToModel()).AsEnumerable(),
-                apis.ToArray().Select(x => x.ToModel()).AsEnumerable());
+                identity.Select(x => x.ToModel()).AsEnumerable(),
+                apis.Select(x => x.ToModel()).AsEnumerable());
 
             _logger.LogDebug("Found {scopes} as all scopes in database", result.IdentityResources.Select(x=>x.Name).Union(result.ApiResources.SelectMany(x=>x.Scopes).Select(x=>x.Name)));
 
-            return Task.FromResult(result);
+            return result;
         }
     }
 }

--- a/src/IdentityServer4.EntityFramework/TokenCleanup.cs
+++ b/src/IdentityServer4.EntityFramework/TokenCleanup.cs
@@ -91,11 +91,11 @@ namespace IdentityServer4.EntityFramework
                     break;
                 }
 
-                ClearTokens();
+                await ClearTokensAsync();
             }
         }
 
-        public void ClearTokens()
+        public async Task ClearTokensAsync()
         {
             try
             {
@@ -109,11 +109,11 @@ namespace IdentityServer4.EntityFramework
                     {
                         while (found >= _options.TokenCleanupBatchSize)
                         {
-                            var expired = context.PersistedGrants
+                            var expired = await context.PersistedGrants
                                 .Where(x => x.Expiration < DateTime.UtcNow)
                                 .OrderBy(x => x.Key)
                                 .Take(_options.TokenCleanupBatchSize)
-                                .ToArray();
+                                .ToArrayAsync();
 
                             found = expired.Length;
                             _logger.LogInformation("Clearing {tokenCount} tokens", found);
@@ -123,7 +123,7 @@ namespace IdentityServer4.EntityFramework
                                 context.PersistedGrants.RemoveRange(expired);
                                 try
                                 {
-                                    context.SaveChanges();
+                                    await context.SaveChangesAsync();
                                 }
                                 catch (DbUpdateConcurrencyException ex)
                                 {

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/DbContexts/ClientDbContextTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/DbContexts/ClientDbContextTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using IdentityServer4.EntityFramework.Entities;
 using IdentityServer4.EntityFramework.Options;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
 {
@@ -23,7 +24,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void CanAddAndDeleteClientScopes(DbContextOptions<ConfigurationDbContext> options)
+        public async Task CanAddAndDeleteClientScopes(DbContextOptions<ConfigurationDbContext> options)
         {
             using (var db = new ConfigurationDbContext(options, StoreOptions))
             {
@@ -33,7 +34,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
                     ClientName = "Test Client"
                 });
 
-                db.SaveChanges();
+                await db.SaveChangesAsync();
             }
 
             using (var db = new ConfigurationDbContext(options, StoreOptions))
@@ -46,7 +47,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
                     Scope = "test"
                 });
 
-                db.SaveChanges();
+                await db.SaveChangesAsync();
             }
 
             using (var db = new ConfigurationDbContext(options, StoreOptions))
@@ -56,7 +57,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
 
                 client.AllowedScopes.Remove(scope);
 
-                db.SaveChanges();
+                await db.SaveChangesAsync();
             }
 
             using (var db = new ConfigurationDbContext(options, StoreOptions))
@@ -68,7 +69,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void CanAddAndDeleteClientRedirectUri(DbContextOptions<ConfigurationDbContext> options)
+        public async Task CanAddAndDeleteClientRedirectUri(DbContextOptions<ConfigurationDbContext> options)
         {
             using (var db = new ConfigurationDbContext(options, StoreOptions))
             {
@@ -78,7 +79,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
                     ClientName = "Test Client"
                 });
 
-                db.SaveChanges();
+                await db.SaveChangesAsync();
             }
 
             using (var db = new ConfigurationDbContext(options, StoreOptions))
@@ -90,7 +91,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
                     RedirectUri = "https://redirect-uri-1"
                 });
 
-                db.SaveChanges();
+                await db.SaveChangesAsync();
             }
 
             using (var db = new ConfigurationDbContext(options, StoreOptions))
@@ -100,7 +101,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
 
                 client.RedirectUris.Remove(redirectUri);
 
-                db.SaveChanges();
+                await db.SaveChangesAsync();
             }
 
             using (var db = new ConfigurationDbContext(options, StoreOptions))

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Services/CorsPolicyServiceTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Services/CorsPolicyServiceTests.cs
@@ -15,6 +15,7 @@ using IdentityServer4.EntityFramework.Options;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using IdentityServer4.EntityFramework.Interfaces;
+using System.Threading.Tasks;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests.Services
 {
@@ -30,7 +31,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Services
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void IsOriginAllowedAsync_WhenOriginIsAllowed_ExpectTrue(DbContextOptions<ConfigurationDbContext> options)
+        public async Task IsOriginAllowedAsync_WhenOriginIsAllowed_ExpectTrue(DbContextOptions<ConfigurationDbContext> options)
         {
             const string testCorsOrigin = "https://identityserver.io/";
 
@@ -48,7 +49,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Services
                     ClientName = "2",
                     AllowedCorsOrigins = new List<string> { "https://www.identityserver.com", testCorsOrigin }
                 }.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             bool result;
@@ -62,14 +63,14 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Services
                 ctxAccessor.HttpContext = ctx;
 
                 var service = new CorsPolicyService(ctxAccessor, FakeLogger<CorsPolicyService>.Create());
-                result = service.IsOriginAllowedAsync(testCorsOrigin).Result;
+                result = await service.IsOriginAllowedAsync(testCorsOrigin);
             }
 
             Assert.True(result);
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void IsOriginAllowedAsync_WhenOriginIsNotAllowed_ExpectFalse(DbContextOptions<ConfigurationDbContext> options)
+        public async Task IsOriginAllowedAsync_WhenOriginIsNotAllowed_ExpectFalse(DbContextOptions<ConfigurationDbContext> options)
         {
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
@@ -79,7 +80,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Services
                     ClientName = Guid.NewGuid().ToString(),
                     AllowedCorsOrigins = new List<string> { "https://www.identityserver.com" }
                 }.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             bool result;
@@ -93,7 +94,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Services
                 ctxAccessor.HttpContext = ctx;
 
                 var service = new CorsPolicyService(ctxAccessor, FakeLogger<CorsPolicyService>.Create());
-                result = service.IsOriginAllowedAsync("InvalidOrigin").Result;
+                result = await service.IsOriginAllowedAsync("InvalidOrigin");
             }
 
             Assert.False(result);

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ClientStoreTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ClientStoreTests.cs
@@ -3,6 +3,7 @@
 
 
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using IdentityServer4.EntityFramework.DbContexts;
 using IdentityServer4.EntityFramework.Mappers;
@@ -26,7 +27,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void FindClientByIdAsync_WhenClientExists_ExpectClientRetured(DbContextOptions<ConfigurationDbContext> options)
+        public async Task FindClientByIdAsync_WhenClientExists_ExpectClientRetured(DbContextOptions<ConfigurationDbContext> options)
         {
             var testClient = new Client
             {
@@ -37,21 +38,21 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 context.Clients.Add(testClient.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             Client client;
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ClientStore(context, FakeLogger<ClientStore>.Create());
-                client = store.FindClientByIdAsync(testClient.ClientId).Result;
+                client = await store.FindClientByIdAsync(testClient.ClientId);
             }
 
             Assert.NotNull(client);
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void FindClientByIdAsync_WhenClientExists_ExpectClientPropertiesRetured(DbContextOptions<ConfigurationDbContext> options)
+        public async Task FindClientByIdAsync_WhenClientExists_ExpectClientPropertiesRetured(DbContextOptions<ConfigurationDbContext> options)
         {
             var testClient = new Client
             {
@@ -67,14 +68,14 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 context.Clients.Add(testClient.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             Client client;
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ClientStore(context, FakeLogger<ClientStore>.Create());
-                client = store.FindClientByIdAsync(testClient.ClientId).Result;
+                client = await store.FindClientByIdAsync(testClient.ClientId);
             }
 
             client.Properties.Should().NotBeNull();

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/PersistedGrantStoreTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/PersistedGrantStoreTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using IdentityServer4.EntityFramework.DbContexts;
 using IdentityServer4.EntityFramework.Mappers;
 using IdentityServer4.EntityFramework.Options;
@@ -41,14 +42,14 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void StoreAsync_WhenPersistedGrantStored_ExpectSuccess(DbContextOptions<PersistedGrantDbContext> options)
+        public async Task StoreAsync_WhenPersistedGrantStored_ExpectSuccess(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                store.StoreAsync(persistedGrant).Wait();
+                await store.StoreAsync(persistedGrant);
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
@@ -59,42 +60,42 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void GetAsync_WithKeyAndPersistedGrantExists_ExpectPersistedGrantReturned(DbContextOptions<PersistedGrantDbContext> options)
+        public async Task GetAsync_WithKeyAndPersistedGrantExists_ExpectPersistedGrantReturned(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 context.PersistedGrants.Add(persistedGrant.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             PersistedGrant foundPersistedGrant;
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                foundPersistedGrant = store.GetAsync(persistedGrant.Key).Result;
+                foundPersistedGrant = await store.GetAsync(persistedGrant.Key);
             }
 
             Assert.NotNull(foundPersistedGrant);
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void GetAsync_WithSubAndTypeAndPersistedGrantExists_ExpectPersistedGrantReturned(DbContextOptions<PersistedGrantDbContext> options)
+        public async Task GetAsync_WithSubAndTypeAndPersistedGrantExists_ExpectPersistedGrantReturned(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 context.PersistedGrants.Add(persistedGrant.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
-            IList<PersistedGrant> foundPersistedGrants;
+            IEnumerable<PersistedGrant> foundPersistedGrants;
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                foundPersistedGrants = store.GetAllAsync(persistedGrant.SubjectId).Result.ToList();
+                foundPersistedGrants = await store.GetAllAsync(persistedGrant.SubjectId);
             }
 
             Assert.NotNull(foundPersistedGrants);
@@ -102,20 +103,20 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void RemoveAsync_WhenKeyOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
+        public async Task RemoveAsync_WhenKeyOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 context.PersistedGrants.Add(persistedGrant.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
             
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                store.RemoveAsync(persistedGrant.Key).Wait();
+                await store.RemoveAsync(persistedGrant.Key);
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
@@ -126,20 +127,20 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void RemoveAsync_WhenSubIdAndClientIdOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
+        public async Task RemoveAsync_WhenSubIdAndClientIdOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 context.PersistedGrants.Add(persistedGrant.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                store.RemoveAllAsync(persistedGrant.SubjectId, persistedGrant.ClientId).Wait();
+                await store.RemoveAllAsync(persistedGrant.SubjectId, persistedGrant.ClientId);
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
@@ -150,20 +151,20 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void RemoveAsync_WhenSubIdClientIdAndTypeOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
+        public async Task RemoveAsync_WhenSubIdClientIdAndTypeOfExistingReceived_ExpectGrantDeleted(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 context.PersistedGrants.Add(persistedGrant.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                store.RemoveAllAsync(persistedGrant.SubjectId, persistedGrant.ClientId, persistedGrant.Type).Wait();
+                await store.RemoveAllAsync(persistedGrant.SubjectId, persistedGrant.ClientId, persistedGrant.Type);
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
@@ -174,7 +175,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void Store_should_create_new_record_if_key_does_not_exist(DbContextOptions<PersistedGrantDbContext> options)
+        public async Task Store_should_create_new_record_if_key_does_not_exist(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
 
@@ -187,7 +188,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
-                store.StoreAsync(persistedGrant).Wait();
+                await store.StoreAsync(persistedGrant);
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
@@ -198,14 +199,14 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void Store_should_update_record_if_key_already_exists(DbContextOptions<PersistedGrantDbContext> options)
+        public async Task Store_should_update_record_if_key_already_exists(DbContextOptions<PersistedGrantDbContext> options)
         {
             var persistedGrant = CreateTestObject();
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 context.PersistedGrants.Add(persistedGrant.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             var newDate = persistedGrant.Expiration.Value.AddHours(1);
@@ -213,7 +214,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             {
                 var store = new PersistedGrantStore(context, FakeLogger<PersistedGrantStore>.Create());
                 persistedGrant.Expiration = newDate;
-                store.StoreAsync(persistedGrant).Wait();
+                await store.StoreAsync(persistedGrant);
             }
 
             using (var context = new PersistedGrantDbContext(options, StoreOptions))

--- a/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ResourceStoreTests.cs
+++ b/test/IdentityServer4.EntityFramework.IntegrationTests/Stores/ResourceStoreTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using IdentityModel;
 using IdentityServer4.EntityFramework.DbContexts;
 using IdentityServer4.EntityFramework.Mappers;
@@ -68,7 +69,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void FindResourcesAsync_WhenResourcesExist_ExpectResourcesReturned(DbContextOptions<ConfigurationDbContext> options)
+        public async Task FindResourcesAsync_WhenResourcesExist_ExpectResourcesReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var testIdentityResource = CreateIdentityTestResource();
             var testApiResource = CreateApiTestResource();
@@ -77,18 +78,18 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             {
                 context.IdentityResources.Add(testIdentityResource.ToEntity());
                 context.ApiResources.Add(testApiResource.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             Resources resources;
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ResourceStore(context, FakeLogger<ResourceStore>.Create());
-                resources = store.FindResourcesByScopeAsync(new List<string>
+                resources = await store.FindResourcesByScopeAsync(new List<string>
                 {
                     testIdentityResource.Name,
                     testApiResource.Scopes.First().Name
-                }).Result;
+                });
             }
 
             Assert.NotNull(resources);
@@ -100,7 +101,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             Assert.NotNull(resources.ApiResources.FirstOrDefault(x => x.Name == testApiResource.Name));
         }
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void FindResourcesAsync_WhenResourcesExist_ExpectOnlyResourcesRequestedReturned(DbContextOptions<ConfigurationDbContext> options)
+        public async Task FindResourcesAsync_WhenResourcesExist_ExpectOnlyResourcesRequestedReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var testIdentityResource = CreateIdentityTestResource();
             var testApiResource = CreateApiTestResource();
@@ -111,18 +112,18 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
                 context.ApiResources.Add(testApiResource.ToEntity());
                 context.IdentityResources.Add(CreateIdentityTestResource().ToEntity());
                 context.ApiResources.Add(CreateApiTestResource().ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             Resources resources;
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ResourceStore(context, FakeLogger<ResourceStore>.Create());
-                resources = store.FindResourcesByScopeAsync(new List<string>
+                resources = await store.FindResourcesByScopeAsync(new List<string>
                 {
                     testIdentityResource.Name,
                     testApiResource.Scopes.First().Name
-                }).Result;
+                });
             }
 
             Assert.NotNull(resources);
@@ -135,7 +136,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void GetAllResources_WhenAllResourcesRequested_ExpectAllResourcesIncludingHidden(DbContextOptions<ConfigurationDbContext> options)
+        public async Task GetAllResources_WhenAllResourcesRequested_ExpectAllResourcesIncludingHidden(DbContextOptions<ConfigurationDbContext> options)
         {
             var visibleIdentityResource = CreateIdentityTestResource();
             var visibleApiResource = CreateApiTestResource();
@@ -152,14 +153,14 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
                 context.ApiResources.Add(visibleApiResource.ToEntity());
                 context.IdentityResources.Add(hiddenIdentityResource.ToEntity());
                 context.ApiResources.Add(hiddenApiResource.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             Resources resources;
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ResourceStore(context, FakeLogger<ResourceStore>.Create());
-                resources = store.GetAllResourcesAsync().Result;
+                resources = await store.GetAllResourcesAsync();
             }
 
             Assert.NotNull(resources);
@@ -171,24 +172,24 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void FindIdentityResourcesByScopeAsync_WhenResourceExists_ExpectResourceAndCollectionsReturned(DbContextOptions<ConfigurationDbContext> options)
+        public async Task FindIdentityResourcesByScopeAsync_WhenResourceExists_ExpectResourceAndCollectionsReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var resource = CreateIdentityTestResource();
 
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 context.IdentityResources.Add(resource.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
-            IList<IdentityResource> resources;
+            IEnumerable<IdentityResource> resources;
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ResourceStore(context, FakeLogger<ResourceStore>.Create());
-                resources = store.FindIdentityResourcesByScopeAsync(new List<string>
+                resources = await store.FindIdentityResourcesByScopeAsync(new List<string>
                 {
                     resource.Name
-                }).Result.ToList();
+                });
             }
 
             Assert.NotNull(resources);
@@ -201,7 +202,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void FindIdentityResourcesByScopeAsync_WhenResourcesExist_ExpectOnlyRequestedReturned(DbContextOptions<ConfigurationDbContext> options)
+        public async Task FindIdentityResourcesByScopeAsync_WhenResourcesExist_ExpectOnlyRequestedReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var resource = CreateIdentityTestResource();
 
@@ -209,40 +210,40 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             {
                 context.IdentityResources.Add(resource.ToEntity());
                 context.IdentityResources.Add(CreateIdentityTestResource().ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
-            IList<IdentityResource> resources;
+            IEnumerable<IdentityResource> resources;
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ResourceStore(context, FakeLogger<ResourceStore>.Create());
-                resources = store.FindIdentityResourcesByScopeAsync(new List<string>
+                resources = await store.FindIdentityResourcesByScopeAsync(new List<string>
                 {
                     resource.Name
-                }).Result.ToList();
+                });
             }
 
             Assert.NotNull(resources);
             Assert.NotEmpty(resources);
-            Assert.Equal(1, resources.Count);
+            Assert.Single(resources);
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void FindApiResourceAsync_WhenResourceExists_ExpectResourceAndCollectionsReturned(DbContextOptions<ConfigurationDbContext> options)
+        public async Task FindApiResourceAsync_WhenResourceExists_ExpectResourceAndCollectionsReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var resource = CreateApiTestResource();
 
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 context.ApiResources.Add(resource.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
             ApiResource foundResource;
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ResourceStore(context, FakeLogger<ResourceStore>.Create());
-                foundResource = store.FindApiResourceAsync(resource.Name).Result;
+                foundResource = await store.FindApiResourceAsync(resource.Name);
             }
 
             Assert.NotNull(foundResource);
@@ -257,21 +258,21 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void FindApiResourcesByScopeAsync_WhenResourceExists_ExpectResourceAndCollectionsReturned(DbContextOptions<ConfigurationDbContext> options)
+        public async Task FindApiResourcesByScopeAsync_WhenResourceExists_ExpectResourceAndCollectionsReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var resource = CreateApiTestResource();
 
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 context.ApiResources.Add(resource.ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
-            IList<ApiResource> resources;
+            IEnumerable<ApiResource> resources;
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ResourceStore(context, FakeLogger<ResourceStore>.Create());
-                resources = store.FindApiResourcesByScopeAsync(new List<string> {resource.Scopes.First().Name}).Result.ToList();
+                resources = await store.FindApiResourcesByScopeAsync(new List<string> {resource.Scopes.First().Name});
             }
 
             Assert.NotEmpty(resources);
@@ -287,7 +288,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         }
 
         [Theory, MemberData(nameof(TestDatabaseProviders))]
-        public void FindApiResourcesByScopeAsync_WhenMultipleResourcesExist_ExpectOnlyRequestedResourcesReturned(DbContextOptions<ConfigurationDbContext> options)
+        public async Task FindApiResourcesByScopeAsync_WhenMultipleResourcesExist_ExpectOnlyRequestedResourcesReturned(DbContextOptions<ConfigurationDbContext> options)
         {
             var resource = CreateApiTestResource();
 
@@ -296,19 +297,19 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
                 context.ApiResources.Add(resource.ToEntity());
                 context.ApiResources.Add(CreateApiTestResource().ToEntity());
                 context.ApiResources.Add(CreateApiTestResource().ToEntity());
-                context.SaveChanges();
+                await context.SaveChangesAsync();
             }
 
-            IList<ApiResource> resources;
+            IEnumerable<ApiResource> resources;
             using (var context = new ConfigurationDbContext(options, StoreOptions))
             {
                 var store = new ResourceStore(context, FakeLogger<ResourceStore>.Create());
-                resources = store.FindApiResourcesByScopeAsync(new List<string> {resource.Scopes.First().Name}).Result.ToList();
+                resources = await store.FindApiResourcesByScopeAsync(new List<string> {resource.Scopes.First().Name});
             }
 
             Assert.NotNull(resources);
             Assert.NotEmpty(resources);
-            Assert.Equal(1, resources.Count);
+            Assert.Single(resources);
         }
     }
 }


### PR DESCRIPTION
Entity Framework fixed their bug with slow async queries, see here: https://github.com/aspnet/EntityFrameworkCore/issues/5816

Switching to this async version improved our load test throughput by ~20%, and reduced 408 request timeout errors significantly. These were caused by thread pool exhaustion, which in turn was caused by threads waiting on results from database.